### PR TITLE
對 zh-TW 的翻譯進行用詞最佳化。

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,6 +24,7 @@
 ## Traditional Chinese (zh-rTW)
 - `孟武．尼德霍格．龍` (via email)
 - `david082321`:  david082321
+- `pan93412`
 
 # Code
 - sffxzzp

--- a/brevent/src/main/res/values-zh-rTW/ops.xml
+++ b/brevent/src/main/res/values-zh-rTW/ops.xml
@@ -9,23 +9,24 @@
     <string name="ops_mode_default">預設</string>
     <string name="ops_mode_ask">詢問</string>
     <string name="ops_mode_unknown">未知</string>
-    <string name="ops_mode_permission">默認權限</string>
+    <string name="ops_mode_permission">預設權限</string>
     <string name="ops_mode_permission_granted">已授權</string>
     <string name="ops_mode_permission_denied">無授權</string>
 
-    <string name="context_menu_appops">應用程式操作</string>
-    <string name="context_menu_ops">複製操作</string>
-    <string name="context_menu_ops_copied">操作已複製: %s</string>
-
-    <string name="ops_time_allow">%s允許</string>
-    <string name="ops_time_reject">%s忽略</string>
+    <string name="context_menu_appops">應用程式動作</string>
+    <string name="context_menu_ops">複製動作</string>
+    <string name="context_menu_ops_copied">動作已複製: %s</string>
+    
+    <!-- [fuzzy] 不確定的量詞 -->
+    <string name="ops_time_allow">%s 次允許</string>
+    <string name="ops_time_reject">%s 次忽略</string>
 
     <string name="ops_menu_allow">@string/ops_mode_allow</string>
     <string name="ops_menu_ignore">@string/ops_mode_ignore</string>
     <string name="ops_menu_reset">還原</string>
     <string name="ops_menu_sort_by_time">時間</string>
     <string name="ops_menu_sort_by_name">名稱</string>
-    <string name="ops_menu_sort_by_group">分組</string>
+    <string name="ops_menu_sort_by_group">群組</string>
     <string name="ops_menu_sort_by_op">代碼</string>
     <string name="ops_menu_sort_by_mode">狀態</string>
 

--- a/brevent/src/main/res/values-zh-rTW/strings.xml
+++ b/brevent/src/main/res/values-zh-rTW/strings.xml
@@ -5,8 +5,8 @@
     <string name="app_name_debug">白域</string>
 
     <string name="fragment_guide_welcome">歡迎</string>
-    <string name="fragment_guide_welcome_message">Android 系統離開應用程式可以透過幾種方式，「返回」按鈕退出應用程式回到上層，「首頁」或「總覽」（Overview）按鈕把應用程式移到背景。 \n\n黑閾透過這種方式識別應用程式狀態，防止「黑閾清單」內應用程式長期執行。</string>
-    <string name="fragment_guide_welcome_message2">當您按「返回」按鈕退出應用程式時，應用程式及所包含的服務不再執行；當您按「首頁」或「總覽」按鈕，或者其它方式把應用程式移到背景，背景應用程式及所包含的服務可以繼續執行；當您從總覽畫面（recents screen）拉掉應用程式時，黑閾將強制停止它。無論何時應用被執行，只要沒有打開界面，黑閾都將強制停止它。\n\n「黑閾清單」內應用程式也可以接收通知或執行同步，只要設定為「允許同步」就好。「允許同步」應用程式不會被待機；有通知或在背景執行時，不會被強制停止。</string>
+    <string name="fragment_guide_welcome_message">Android 系統離開應用程式可以透過幾種方式，「返回」按鈕退出應用程式回到上層，「首頁」或「總覽」（Overview）按鈕把應用程式移到背景。 \n\n黑閾透過這種方式辨識應用程式狀態，防止「黑閾清單」內應用程式長期執行。</string>
+    <string name="fragment_guide_welcome_message2">當您按「返回」按鈕退出應用程式時，應用程式及所包含的服務不再執行；當您按「首頁」或「總覽」按鈕，或者其它方式把應用程式移到背景，背景應用程式及所包含的服務可以繼續執行；當您從總覽畫面（recents screen）拉掉應用程式時，黑閾將強制停止它。無論何時應用被執行，只要沒有打開介面，黑閾都將強制停止它。\n\n「黑閾清單」內應用程式也可以接收通知或執行同步，只要設定為「允許同步」就好。「允許同步」應用程式不會被待機；有通知或在背景執行時，不會被強制停止。</string>
 
     <string name="fragment_guide_permission">權限</string>
     <string name="fragment_guide_permission_message">黑閾需要在您每次開機以後，以「USB 偵錯」模式執行一個指令開啟黑閾服務，讓黑閾間接的具備管理其它應用程式的權限。</string>
@@ -17,7 +17,7 @@
     <string name="fragment_guide_security_message2">黑閾使用大量 Android 隱藏 API，部分廠商可能改變這些 API 行為，使用黑閾可能會對應用程式甚至裝置造成不良影響。\n\n不要在工作裝置上使用黑閾，也不要黑閾工作應用程式、常用應用程式和重要應用程式。</string>
 
     <string name="fragment_guide_enjoy">使用</string>
-    <string name="fragment_guide_enjoy_message">請盡情享受黑閾，發現任何問題，歡迎附上日誌發送回饋。</string>
+    <string name="fragment_guide_enjoy_message">請盡情享受黑閾，發現任何問題，歡迎附上日誌傳送回報。</string>
     <string name="fragment_guide_enjoy_message2">預設黑閾方法為「待機，然後強制停止」。應用程式待機（App Standby，Android 6.0 引入，部分裝置不支援）後不能聯網、執行任務（Job）與同步。\n\n黑閾不強制停止安全的緩存應用程式。此外，黑閾集中處理，根據事件級別延後 3 到 60 秒不等。</string>
     <string name="start_brevent">進入黑閾</string>
 
@@ -63,7 +63,7 @@
     <string name="process_service">%d 個服務</string>
     <string name="process_total">共 %d 個</string>
     <plurals name="process_process">
-        <item quantity="other">程序</item>
+        <item quantity="other">程式</item>
     </plurals>
 
     <string name="action_brevent">加入黑閾</string>
@@ -76,23 +76,23 @@
     <string name="action_message_undone">已還原</string>
 
     <string name="context_menu_target">API %1$d（%2$s）</string>
-    <string name="context_menu_package_name">複製安裝包（Package）名稱</string>
+    <string name="context_menu_package_name">複製軟體包（Package）名稱</string>
     <string name="context_menu_app_info">應用程式資訊</string>
     <string name="context_menu_open">開啟</string>
     <string name="context_menu_brevent_server_info">黑閾服務資訊</string>
     <string name="context_menu_set_priority">允許同步</string>
     <string name="context_menu_unset_priority">取消同步</string>
-    <string name="context_menu_message_copied">安裝包（Package）名稱已複製: %s</string>
+    <string name="context_menu_message_copied">軟體包（Package）名稱已複製: %s</string>
     <string name="context_menu_disable">停用</string>
     <string name="context_menu_enable">啟用</string>
-    <string name="context_menu_enable_open">臨時啟用</string>
+    <string name="context_menu_enable_open">暫時啟用</string>
 
     <string name="important_input">%s（輸入法）</string>
     <string name="important_alarm">%s（鬧鐘應用程式）</string>
     <string name="important_sms">%s（簡訊應用程式）</string>
     <string name="important_home">%s（主畫面應用程式）</string>
-    <string name="important_persistent">%s（永久處理程序）</string>
-    <string name="important_android">%s（Android 處理程序）</string>
+    <string name="important_persistent">%s（永久處理程式）</string>
+    <string name="important_android">%s（Android 處理程式）</string>
     <string name="important_dialer">%s（電話應用程式）</string>
     <string name="important_assistant">%s（小幫手應用程式）</string>
     <string name="important_webview">%s（WebView 實作）</string>
@@ -112,16 +112,16 @@
     <string name="menu_sort_by_update_time">更新時間</string>
     <string name="menu_sort_by_last_time">上次使用時間</string>
     <string name="menu_sort_by_usage_time">使用時長</string>
-    <string name="menu_feedback">回饋</string>
+    <string name="menu_feedback">回報</string>
     <string name="menu_settings">設定</string>
-    <string name="menu_guide">指引</string>
-    <string name="menu_template">模板</string>
+    <string name="menu_guide">指引教學</string>
+    <string name="menu_template">範本</string>
     <string name="menu_command">執行指令</string>
 
-    <string name="feedback_message">歡迎傳送回饋。\n\n如果您有 GitHub 帳號，請直接建立一個問題；您也可以檢視其他朋友已經建立的問題。%s</string>
-    <string name="feedback_message_email">\n\n如果您的回饋包含私人資料，請傳送郵件。</string>
+    <string name="feedback_message">歡迎傳送回報。\n\n如果您有 GitHub 帳號，請直接建立一個問題；您也可以檢視其他朋友已經建立的問題。%s</string>
+    <string name="feedback_message_email">\n\n如果您的回報包含私人資料，請傳送至信箱。</string>
     <string name="feedback_github">GitHub</string>
-    <string name="feedback_email">郵件</string>
+    <string name="feedback_email">信箱</string>
     <string name="feedback_logs">日誌</string>
 
     <string name="brevent_list">黑閾清單</string>
@@ -131,11 +131,11 @@
     <string name="brevent_method_standby_forcestop">待機，然後強制停止</string>
     <string name="brevent_method_standby_only">只待機，不強制停止</string>
     <string name="brevent_method_forcestop_only">只強制停止，不待機</string>
-    <string name="brevent_method_standby_forcestop_label">退出應用程式（如輕觸「返回」按鈕），或者背景應用程式逾時後先待命；待命逾時，或者從總覽畫面拉掉後強制停止\n\n針對被執行但沒有打開界面的應用程式，一律強制停止</string>
-    <string name="brevent_method_standby_only_label">退出應用程式（如輕觸「返回」按鈕），或者背景應用程式逾時後待命\n\n針對被執行但有打開界面的應用程式，一律強制停止</string>
-    <string name="brevent_method_forcestop_only_label">退出應用程式（如輕觸「返回」按鈕），或者背景應用程式逾時，或者從總覽畫面拉掉後強制停止\n\n針對被執行但沒有打開界面的應用程式，一律強制停止</string>
+    <string name="brevent_method_standby_forcestop_label">退出應用程式（如輕觸「返回」按鈕），或者背景應用程式逾時後先待命；待命逾時，或者從總覽畫面拉掉後強制停止\n\n針對被執行但沒有打開介面的應用程式，一律強制停止</string>
+    <string name="brevent_method_standby_only_label">退出應用程式（如輕觸「返回」按鈕），或者背景應用程式逾時後待命\n\n針對被執行但有打開介面的應用程式，一律強制停止</string>
+    <string name="brevent_method_forcestop_only_label">退出應用程式（如輕觸「返回」按鈕），或者背景應用程式逾時，或者從總覽畫面拉掉後強制停止\n\n針對被執行但沒有打開介面的應用程式，一律強制停止</string>
     <string name="brevent_timeout">背景應用程式逾時</string>
-    <string name="brevent_timeout_label">離開背景應用程式 %1$s 後\n\n背景應用程式是指您還未結束的應用程式，主介面動態顯示離開時間</string>
+    <string name="brevent_timeout_label">離開背景應用程式 %1$s 後\n\n背景應用程式是指您還未結束的應用程式，主畫面動態顯示離開時間</string>
     <string name="brevent_timeout_1min">1 分鐘</string>
     <string name="brevent_timeout_5min">5 分鐘</string>
     <string name="brevent_timeout_15min">15 分鐘</string>
@@ -145,10 +145,10 @@
     <string name="brevent_timeout_6hour">6 小時</string>
     <string name="brevent_timeout_long">很久</string>
     <string name="brevent_standby_timeout">待機逾時</string>
-    <string name="brevent_standby_timeout_label">應用程式待命 %1$s 後強制停止，主界面不顯示待命時間長度</string>
+    <string name="brevent_standby_timeout_label">應用程式待命 %1$s 後強制停止，主畫面不顯示待命時間長度</string>
 
     <string name="brevent_advanced">進階功能</string>
-    <string name="brevent_language">界面語言</string>
+    <string name="brevent_language">介面語言</string>
     <string name="brevent_language_auto">與系統同步</string>
     <string name="show_framework_apps">顯示框架應用程式</string>
     <string name="show_framework_apps_label">所有與系統框架簽名相同的應用程式\n\n請謹慎黑閾框架應用程式</string>
@@ -158,23 +158,23 @@
     <string name="brevent_checking">自我診斷</string>
     <string name="brevent_checking_label">每 15 分鐘檢查黑閾服務\n\n只有偶然不正常停止時，才需要開啟</string>
 
-    <string name="brevent_optimize">優化功能</string>
-    <string name="brevent_abnormal_back">識別非正常「返回」</string>
+    <string name="brevent_optimize">最佳化功能</string>
+    <string name="brevent_abnormal_back">辨識非正常「返回」</string>
     <string name="brevent_abnormal_back_label">應用程式不是使用「首頁」（如「返回」）方式回到桌面時，立即黑閾</string>
-    <string name="brevent_optimize_audio">優化音樂應用程式</string>
+    <string name="brevent_optimize_audio">最佳化音樂應用程式</string>
     <string name="brevent_optimize_audio_label">播放且有通知時不黑閾，暫停且有通知時不強行停止</string>
     <string name="show_os_apps">顯示作業系統應用程式</string>
     <string name="show_os_apps_label">依賴「顯示框架應用程式」。作業系統應用程式無法黑閾</string>
 
-    <string name="show_donation">顯示支付</string>
+    <string name="show_donation">顯示付款</string>
     <string name="show_donation_summary_play" />
-    <string name="show_donation_play">感謝您透過 Play 商店支付 %s 二向箔</string>
-    <string name="show_donation_rmb">感謝您支付 %s 二向箔</string>
+    <string name="show_donation_play">感謝您透過 Play 商店付款 %s 二向箔</string>
+    <string name="show_donation_rmb">感謝您付款 %s 二向箔</string>
     <string name="show_donation_contributor">感謝您為黑閾所作的特別貢獻</string>
-    <string name="show_donation_play_and_rmb">感謝您透過 Play 商店支付 %1$s 二向箔，非 Play 支付 %2$s 二向箔</string>
-    <string name="show_donation_play_and_contributor">感謝您透過 Play 商店支付 %s 二向箔，以及為黑閾所作的特別貢獻</string>
-    <string name="show_donation_rmb_and_contributor">感謝您支付 %s 二向箔，以及為黑閾所作的特別貢獻</string>
-    <string name="show_donation_play_and_rmb_and_contributor">感謝您透過 Play 商店支付 %1$s 二向箔，非 Play 支付 %2$s 二向箔，以及為黑閾所作的特別貢獻</string>
+    <string name="show_donation_play_and_rmb">感謝您透過 Play 商店付款 %1$s 二向箔，非 Play 付款 %2$s 二向箔</string>
+    <string name="show_donation_play_and_contributor">感謝您透過 Play 商店付款 %s 二向箔，以及為黑閾所作的特別貢獻</string>
+    <string name="show_donation_rmb_and_contributor">感謝您付款 %s 二向箔，以及為黑閾所作的特別貢獻</string>
+    <string name="show_donation_play_and_rmb_and_contributor">感謝您透過 Play 商店付款 %1$s 二向箔，非 Play 付款 %2$s 二向箔，以及為黑閾所作的特別貢獻</string>
     <string name="show_donation_xposed">（Xposed）</string>
     <string name="show_donation_brefoil" />
     <string name="brevent_appops">應用程式操作</string>
@@ -182,7 +182,7 @@
     <string name="brevent_disable">停用應用程式</string>
     <string name="brevent_disable_label">停用以後，必須先啟用才能繼續使用</string>
     <string name="brevent_dynamic">動態停用（實驗性）</string>
-    <string name="brevent_dynamic_label">如果應用程式被運行且有通知，將被動態停用</string>
+    <string name="brevent_dynamic_label">如果應用程式被執行且有通知，將被動態停用</string>
 
     <string name="brevent_about">關於</string>
     <string name="brevent_about_system">系統狀態</string>
@@ -192,17 +192,17 @@
     <string name="brevent_about_developer">開發人員選項</string>
     <string name="brevent_about_developer_adb">已啟用「USB 偵錯」</string>
     <string name="brevent_about_translation">翻譯</string>
-    <string name="brevent_about_translator">孟武．尼德霍格．龍\ndavid082321</string>
+    <string name="brevent_about_translator">孟武．尼德霍格．龍\ndavid082321\n\npan93412\n（負責修正翻譯）</string>
     <string name="brevent_about_licenses">軟體授權</string>
 
     <string name="unsupported_owner">只有擁有者可以使用黑閾。</string>
     <string name="unsupported_clone">黑閾不適用於 App clone。</string>
     <string name="unsupported_signature">請勿破解黑閾。</string>
-    <string name="unsupported_xposed">請禁用 Xposed 以便使用黑閾。</string>
-    <string name="unsupported_path">（錯誤：無法生成指令文件）</string>
+    <string name="unsupported_xposed">請停用 Xposed 以便使用黑閾。</string>
+    <string name="unsupported_path">（錯誤：無法生成指令檔案）</string>
     <string name="unsupported_permission">沒有權限存取黑閾服務。\n\n前景應用程式：%1$s。</string>
     <string name="unsupported_no_event">沒有事件日誌，黑閾無法自動工作。\n\n請稍後重試，或者聯絡 Rom 提供商。</string>
-    <string name="unsupported_no_event2">自 %1$s 起沒有事件日志，黑閾不再自動工作。\n\n請重啟黑閾服務，或者聯絡 Rom 提供商。</string>
+    <string name="unsupported_no_event2">自 %1$s 起沒有事件日誌，黑閾不再自動工作。\n\n請重啟黑閾服務，或者聯絡 Rom 提供商。</string>
     <string name="unsupported_version_mismatched">黑閾服務正在升級，請稍候重試。</string>
     <string name="unsupported_logs">無法取得日誌，請稍候重試。</string>
     <string name="unsupported_shell">無法開啟黑閾服務。</string>
@@ -215,23 +215,23 @@
     <string name="unsupported_brevented">您已黑閾重要應用程式：%1$s。\n\n是否需要不再黑閾？</string>
     <string name="apps_join">、</string>
 
-    <string name="toast_working">黑閾服務運行正常</string>
-    <string name="toast_alipay">感謝您透過支付寶累計支付 %1$s 二向箔</string>
-    <string name="toast_alipay_single">感謝您本次透過支付寶支付 %1$s 二向箔</string>
+    <string name="toast_working">黑閾服務執行正常</string>
+    <string name="toast_alipay">感謝您透過付款寶累計付款 %1$s 二向箔</string>
+    <string name="toast_alipay_single">感謝您本次透過付款寶付款 %1$s 二向箔</string>
     <string name="toast_xposed">@string/show_donation_xposed</string>
-    <string name="toast_alipay_ok">如果已經支付，請點按「轉賬記錄」自動識別</string>
-    <string name="toast_alipay_ko">無法自動確認，請不要支付</string>
-    <string name="toast_donate">感謝您支付 %1$s 二向箔</string>
+    <string name="toast_alipay_ok">如果已經付款，請點按「轉帳記錄」自動辨識</string>
+    <string name="toast_alipay_ko">無法自動確認，請不要付款</string>
+    <string name="toast_donate">感謝您付款 %1$s 二向箔</string>
 
     <string name="brevent_status_starting">正在開啟黑閾服務</string>
     <string name="brevent_status_not_started">黑閾服務沒有開啟</string>
     <string name="brevent_status_stopped">黑閾服務已經停止</string>
     <string name="brevent_status_unknown">黑閾服務可能已經停止</string>
-    <string name="brevent_status_report">請按此發送報告並描述問題</string>
+    <string name="brevent_status_report">請按此傳送報告並描述問題</string>
 
-    <string name="make_brevent_better">您已黑閾 %1$d 個應用程式，請考慮支付 %2$s以促進黑閾良性發展。</string>
-    <string name="pay_brevent_recommend">建議支付 %s</string>
-    <string name="pay_brevent_require">需要支付 %s</string>
+    <string name="make_brevent_better">您已黑閾 %1$d 個應用程式，請考慮付款 %2$s以促進黑閾良性發展。</string>
+    <string name="pay_brevent_recommend">建議付款 %s</string>
+    <string name="pay_brevent_require">需要付款 %s</string>
     <string name="pay_brevent_confirm" />
 
     <string name="brevented_app">已黑閾「%1$s」</string>
@@ -244,8 +244,8 @@
 
     <string name="cmd_menu_reset">重設</string>
     <string name="cmd_menu_stop">停止</string>
-    <string name="cmd_menu_batterystats">取得電量數據</string>
-    <string name="cmd_menu_portal">更新網路檢測</string>
+    <string name="cmd_menu_batterystats">取得電量資訊</string>
+    <string name="cmd_menu_portal">更新網路偵測</string>
     <string name="cmd_too_large">%1$s\n# 錯誤：輸出 %2$d > %3$d</string>
     <string name="cmd_warning">執行指令可能會對應用程式甚至裝置造成不良影響。如有疑問，請立即終止。</string>
 

--- a/donation/src/main/res/values-zh-rTW/strings.xml
+++ b/donation/src/main/res/values-zh-rTW/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="donation">如果您喜歡，請隨意支付</string>
-    <string name="donation_unsupported">暫不支援支付</string>
+    <string name="donation">如果您喜歡，請隨意付費</string>
+    <string name="donation_unsupported">暫不支援付費</string>
     <string name="donation_play_unavailable">無法使用 Play 商店內購</string>
     <string name="donation_play_checking">正在檢查 Play 商店內購…</string>
 


### PR DESCRIPTION
相關變更如下：

- 將用詞的部份台灣化（e.g 優化→最佳化）
- 對某些翻譯做修改 （e.g %s允許→%s 次允許，此處是增加原來沒有的量詞。）
- 增加貢獻者（我）

~删除私人信息~